### PR TITLE
Add sensu-plugin custom check definition attributes

### DIFF
--- a/sensu/check/check.go
+++ b/sensu/check/check.go
@@ -8,14 +8,18 @@ const (
 )
 
 type Check struct {
-	Name        string    `json:"name,omitempty"`
-	Type        CheckType `json:"type,omitempty"`
-	Command     string    `json:"command,omitempty"`
-	Extension   string    `json:"extension,omitempty"`
-	Standalone  bool      `json:"standalone,omitempty"`
-	Subscribers []string  `json:"subscribers,omitempty"`
-	Handler     string    `json:"handler,omitempty"`
-	Handlers    []string  `json:"handlers,omitempty"`
-	Source      string    `json:"source,omitempty"`
-	Interval    int64     `json:"interval,omitempty"`
+	Name         string    `json:"name,omitempty"`
+	Type         CheckType `json:"type,omitempty"`
+	Command      string    `json:"command,omitempty"`
+	Extension    string    `json:"extension,omitempty"`
+	Standalone   bool      `json:"standalone,omitempty"`
+	Subscribers  []string  `json:"subscribers,omitempty"`
+	Handler      string    `json:"handler,omitempty"`
+	Handlers     []string  `json:"handlers,omitempty"`
+	Source       string    `json:"source,omitempty"`
+	Interval     int64     `json:"interval,omitempty"`
+	Occurrences  int64     `json:"occurrences,omitempty"`
+	Refresh      int64     `json:"refresh,omitempty"`
+	Dependencies []string  `json:"dependencies,omitempty"`
+	Notification string    `json:"notification,omitempty"`
 }


### PR DESCRIPTION
Sensu plugins make use of ad-hoc [custom check attributes](https://sensuapp.org/docs/latest/reference/checks.html#custom-attributes).

The official documentation mentions some [common attributes](https://sensuapp.org/docs/latest/reference/plugins.html#sensu-plugin-definition-specification) (`occurrences`, `refresh`, `dependencies` and `notification`) which are used by most plugins.

This PR addresses #1 by adding support for the above-mentioned common attributes, allowing clients to make use of them in standalone checks.