### PR TITLE
Add basic support for RabbitMQ High Availability connections

### DIFF
--- a/sensu/transport/rabbitmq/rabbitmq.go
+++ b/sensu/transport/rabbitmq/rabbitmq.go
@@ -2,20 +2,37 @@ package rabbitmq
 
 import (
 	"errors"
-	"github.com/upfluence/sensu-go/Godeps/_workspace/src/github.com/upfluence/goutils/log"
+	"math/rand"
+	"time"
 
-	"github.com/upfluence/sensu-go/Godeps/_workspace/src/github.com/streadway/amqp"
+	"github.com/upfluence/sensu-client-go/Godeps/_workspace/src/github.com/upfluence/goutils/log"
+
+	"github.com/upfluence/sensu-client-go/Godeps/_workspace/src/github.com/streadway/amqp"
 )
 
 type RabbitMQTransport struct {
-	URI            string
 	Connection     *amqp.Connection
 	Channel        *amqp.Channel
 	ClosingChannel chan bool
+	Configs        []*RabbitMQTransportConfig
 }
 
-func NewRabbitMQTransport(uri string) *RabbitMQTransport {
-	return &RabbitMQTransport{URI: uri, ClosingChannel: make(chan bool)}
+func NewRabbitMQTransport(uri string) (*RabbitMQTransport, error) {
+	config, err := NewRabbitMQTransportConfig(uri)
+
+	if err != nil {
+		log.Errorf("Received invalid URI %s", err)
+		return nil, err
+	}
+
+	return NewRabbitMQHATransport([]*RabbitMQTransportConfig{config}), nil
+}
+
+func NewRabbitMQHATransport(configs []*RabbitMQTransportConfig) *RabbitMQTransport {
+	return &RabbitMQTransport{
+		ClosingChannel: make(chan bool),
+		Configs:        configs,
+	}
 }
 
 func (t *RabbitMQTransport) GetClosingChan() chan bool {
@@ -23,9 +40,45 @@ func (t *RabbitMQTransport) GetClosingChan() chan bool {
 }
 
 func (t *RabbitMQTransport) Connect() error {
+	var uri string
 	var err error
+	randGenerator := rand.New(rand.NewSource(time.Now().UnixNano()))
 
-	t.Connection, err = amqp.Dial(t.URI)
+	for _, idx := range randGenerator.Perm(len(t.Configs)) {
+		config := t.Configs[idx]
+		uri = config.GetURI()
+
+		log.Noticef("Trying to connect to URI: %s", uri)
+
+		// TODO: Figure out how to specify the Prefetch value as well
+		// See amqp.Channel.Qos (it doesn't seem to be used currently)
+
+		// TODO: Add SSL support via amqp.DialTLS
+
+		heartbeatString := config.Heartbeat.String()
+		if heartbeatString == "" {
+			heartbeat, err := time.ParseDuration(heartbeatString)
+
+			if err != nil {
+				log.Warningf("Failed to parse the heartbeat: %s", uri, err.Error())
+				continue
+			}
+
+			t.Connection, err = amqp.DialConfig(uri, amqp.Config{
+				Heartbeat: heartbeat,
+			})
+		} else {
+			// Use amqp.defaultHeartbeat (10s)
+			t.Connection, err = amqp.Dial(uri)
+		}
+
+		if err != nil {
+			log.Warningf("Failed to connect to URI %s: %s", uri, err.Error())
+			continue
+		}
+
+		break
+	}
 
 	if err != nil {
 		log.Errorf("RabbitMQ connection error: %s", err.Error())
@@ -39,7 +92,7 @@ func (t *RabbitMQTransport) Connect() error {
 		return err
 	}
 
-	log.Noticef("RabbitMQ connection and channel opened to %s", t.URI)
+	log.Noticef("RabbitMQ connection and channel opened to %s", uri)
 
 	closeChan := make(chan *amqp.Error)
 	t.Channel.NotifyClose(closeChan)

--- a/sensu/transport/rabbitmq/rabbitmq.go
+++ b/sensu/transport/rabbitmq/rabbitmq.go
@@ -57,7 +57,8 @@ func (t *RabbitMQTransport) Connect() error {
 
 		heartbeatString := config.Heartbeat.String()
 		if heartbeatString != "" {
-			heartbeat, err := time.ParseDuration(heartbeatString)
+			var heartbeat time.Duration
+			heartbeat, err = time.ParseDuration(heartbeatString)
 
 			if err != nil {
 				log.Warningf("Failed to parse the heartbeat: %s", uri, err.Error())

--- a/sensu/transport/rabbitmq/rabbitmq.go
+++ b/sensu/transport/rabbitmq/rabbitmq.go
@@ -14,21 +14,21 @@ type RabbitMQTransport struct {
 	Connection     *amqp.Connection
 	Channel        *amqp.Channel
 	ClosingChannel chan bool
-	Configs        []*RabbitMQTransportConfig
+	Configs        []*TransportConfig
 }
 
 func NewRabbitMQTransport(uri string) (*RabbitMQTransport, error) {
-	config, err := NewRabbitMQTransportConfig(uri)
+	config, err := NewTransportConfig(uri)
 
 	if err != nil {
 		log.Errorf("Received invalid URI %s", err)
 		return nil, err
 	}
 
-	return NewRabbitMQHATransport([]*RabbitMQTransportConfig{config}), nil
+	return NewRabbitMQHATransport([]*TransportConfig{config}), nil
 }
 
-func NewRabbitMQHATransport(configs []*RabbitMQTransportConfig) *RabbitMQTransport {
+func NewRabbitMQHATransport(configs []*TransportConfig) *RabbitMQTransport {
 	return &RabbitMQTransport{
 		ClosingChannel: make(chan bool),
 		Configs:        configs,

--- a/sensu/transport/rabbitmq/rabbitmq.go
+++ b/sensu/transport/rabbitmq/rabbitmq.go
@@ -39,9 +39,11 @@ func (t *RabbitMQTransport) GetClosingChan() chan bool {
 }
 
 func (t *RabbitMQTransport) Connect() error {
-	var uri string
-	var err error
-	randGenerator := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var (
+		uri           string
+		err           error
+		randGenerator = rand.New(rand.NewSource(time.Now().UnixNano()))
+	)
 
 	for _, idx := range randGenerator.Perm(len(t.Configs)) {
 		config := t.Configs[idx]
@@ -64,9 +66,10 @@ func (t *RabbitMQTransport) Connect() error {
 				continue
 			}
 
-			t.Connection, err = amqp.DialConfig(uri, amqp.Config{
-				Heartbeat: heartbeat,
-			})
+			t.Connection, err = amqp.DialConfig(
+				uri,
+				amqp.Config{Heartbeat: heartbeat},
+			)
 		} else {
 			// Use amqp.defaultHeartbeat (10s)
 			t.Connection, err = amqp.Dial(uri)

--- a/sensu/transport/rabbitmq/rabbitmq.go
+++ b/sensu/transport/rabbitmq/rabbitmq.go
@@ -58,7 +58,7 @@ func (t *RabbitMQTransport) Connect() error {
 		heartbeatString := config.Heartbeat.String()
 		if heartbeatString != "" {
 			var heartbeat time.Duration
-			heartbeat, err = time.ParseDuration(heartbeatString)
+			heartbeat, err = time.ParseDuration(heartbeatString + "s")
 
 			if err != nil {
 				log.Warningf("Failed to parse the heartbeat: %s", uri, err.Error())

--- a/sensu/transport/rabbitmq/rabbitmq.go
+++ b/sensu/transport/rabbitmq/rabbitmq.go
@@ -5,9 +5,8 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/upfluence/sensu-client-go/Godeps/_workspace/src/github.com/upfluence/goutils/log"
-
 	"github.com/upfluence/sensu-client-go/Godeps/_workspace/src/github.com/streadway/amqp"
+	"github.com/upfluence/sensu-client-go/Godeps/_workspace/src/github.com/upfluence/goutils/log"
 )
 
 type RabbitMQTransport struct {

--- a/sensu/transport/rabbitmq/rabbitmq.go
+++ b/sensu/transport/rabbitmq/rabbitmq.go
@@ -56,7 +56,7 @@ func (t *RabbitMQTransport) Connect() error {
 		// TODO: Add SSL support via amqp.DialTLS
 
 		heartbeatString := config.Heartbeat.String()
-		if heartbeatString == "" {
+		if heartbeatString != "" {
 			heartbeat, err := time.ParseDuration(heartbeatString)
 
 			if err != nil {

--- a/sensu/transport/rabbitmq/rabbitmq.go
+++ b/sensu/transport/rabbitmq/rabbitmq.go
@@ -6,8 +6,8 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/upfluence/sensu-client-go/Godeps/_workspace/src/github.com/streadway/amqp"
-	"github.com/upfluence/sensu-client-go/Godeps/_workspace/src/github.com/upfluence/goutils/log"
+	"github.com/upfluence/sensu-go/Godeps/_workspace/src/github.com/streadway/amqp"
+	"github.com/upfluence/sensu-go/Godeps/_workspace/src/github.com/upfluence/goutils/log"
 )
 
 type RabbitMQTransport struct {

--- a/sensu/transport/rabbitmq/rabbitmq.go
+++ b/sensu/transport/rabbitmq/rabbitmq.go
@@ -2,6 +2,7 @@ package rabbitmq
 
 import (
 	"errors"
+	"fmt"
 	"math/rand"
 	"time"
 
@@ -20,8 +21,7 @@ func NewRabbitMQTransport(uri string) (*RabbitMQTransport, error) {
 	config, err := NewTransportConfig(uri)
 
 	if err != nil {
-		log.Errorf("Received invalid URI %s", err)
-		return nil, err
+		return nil, fmt.Errorf("Received invalid URI: %s", err)
 	}
 
 	return NewRabbitMQHATransport([]*TransportConfig{config}), nil

--- a/sensu/transport/rabbitmq/rabbitmq_config.go
+++ b/sensu/transport/rabbitmq/rabbitmq_config.go
@@ -1,0 +1,74 @@
+package rabbitmq
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+
+	"github.com/upfluence/goutils/log"
+)
+
+type RabbitMQTransportConfig struct {
+	Host      string      `json:"host,omitempty"`
+	Port      json.Number `json:"port,omitempty"`
+	Vhost     string      `json:"vhost,omitempty"`
+	User      string      `json:"user,omitempty"`
+	Password  string      `json:"password,omitempty"`
+	Heartbeat json.Number `json:"heartbeat,omitempty"`
+	Prefetch  json.Number `json:"prefetch,omitempty"`
+	Ssl       struct {
+		CertChainFile  string `json:"cert_chain_file,omitempty"`
+		PrivateKeyFile string `json:"private_key_file,omitempty"`
+	} `json:"ssl,omitempty"`
+
+	uri string `json:"-"`
+}
+
+func (c *RabbitMQTransportConfig) GetURI() string {
+	if c.uri == "" {
+		c.uri = fmt.Sprintf(
+			"amqp://%s:%s@%s:%s/%s",
+			c.User,
+			c.Password,
+			c.Host,
+			c.Port.String(),
+			url.QueryEscape(c.Vhost),
+		)
+	}
+
+	return c.uri
+}
+
+func NewRabbitMQTransportConfig(uri string) (*RabbitMQTransportConfig, error) {
+	uriComponents, err := url.Parse(uri)
+	if err != nil {
+		log.Errorf("Failed to parse the URI: %s", err)
+		return nil, err
+	}
+
+	if !strings.Contains(uriComponents.Host, ":") {
+		message := fmt.Sprintf("Failed to determine the port for host: %s", uriComponents.Host)
+		log.Error(message)
+		return nil, errors.New(message)
+	}
+
+	host, port, err := net.SplitHostPort(uriComponents.Host)
+	if err != nil {
+		log.Errorf("Failed to separate the host name from the port: %s", err)
+		return nil, err
+	}
+
+	user := uriComponents.User.Username()
+	password, _ := uriComponents.User.Password()
+
+	return &RabbitMQTransportConfig{
+		Host:     host,
+		Port:     json.Number(port),
+		Vhost:    uriComponents.Path[1:], // Discard the leading slash
+		User:     user,
+		Password: password,
+	}, nil
+}

--- a/sensu/transport/rabbitmq/rabbitmq_config.go
+++ b/sensu/transport/rabbitmq/rabbitmq_config.go
@@ -25,23 +25,17 @@ type TransportConfig struct {
 		CertChainFile  string `json:"cert_chain_file,omitempty"`
 		PrivateKeyFile string `json:"private_key_file,omitempty"`
 	} `json:"ssl,omitempty"`
-
-	uri string `json:"-"`
 }
 
 func (c *TransportConfig) GetURI() string {
-	if c.uri == "" {
-		c.uri = fmt.Sprintf(
-			"amqp://%s:%s@%s:%s/%s",
-			c.User,
-			c.Password,
-			c.Host,
-			c.Port.String(),
-			url.QueryEscape(c.Vhost),
-		)
-	}
-
-	return c.uri
+	return fmt.Sprintf(
+		"amqp://%s:%s@%s:%s/%s",
+		c.User,
+		c.Password,
+		c.Host,
+		c.Port.String(),
+		url.QueryEscape(c.Vhost),
+	)
 }
 
 func NewTransportConfig(uri string) (*TransportConfig, error) {

--- a/sensu/transport/rabbitmq/rabbitmq_config.go
+++ b/sensu/transport/rabbitmq/rabbitmq_config.go
@@ -7,8 +7,6 @@ import (
 	"net"
 	"net/url"
 	"strings"
-
-	"github.com/upfluence/goutils/log"
 )
 
 var errNoUserInURI = errors.New("No user found in URI")
@@ -41,20 +39,16 @@ func (c *TransportConfig) GetURI() string {
 func NewTransportConfig(uri string) (*TransportConfig, error) {
 	uriComponents, err := url.Parse(uri)
 	if err != nil {
-		log.Errorf("Failed to parse the URI: %s", err)
-		return nil, err
+		return nil, fmt.Errorf("Failed to parse the URI: %s", err)
 	}
 
 	if !strings.Contains(uriComponents.Host, ":") {
-		message := fmt.Sprintf("Failed to determine the port for host: %s", uriComponents.Host)
-		log.Error(message)
-		return nil, errors.New(message)
+		return nil, fmt.Errorf("Failed to determine the port for host: %s", uriComponents.Host)
 	}
 
 	host, port, err := net.SplitHostPort(uriComponents.Host)
 	if err != nil {
-		log.Errorf("Failed to separate the host name from the port: %s", err)
-		return nil, err
+		return nil, fmt.Errorf("Failed to separate the host name from the port: %s", err)
 	}
 
 	if uriComponents.User == nil {

--- a/sensu/transport/rabbitmq/rabbitmq_config_test.go
+++ b/sensu/transport/rabbitmq/rabbitmq_config_test.go
@@ -81,7 +81,7 @@ var transportConfigErrorTestScenarios = []struct {
 	},
 	{
 		"://",
-		errors.New("parse ://: missing protocol scheme"),
+		errors.New("Failed to parse the URI: parse ://: missing protocol scheme"),
 	},
 	{
 		"amqp://example.com/",
@@ -89,7 +89,7 @@ var transportConfigErrorTestScenarios = []struct {
 	},
 	{
 		"amqp://example.com::",
-		errors.New("too many colons in address example.com::"),
+		errors.New("Failed to separate the host name from the port: too many colons in address example.com::"),
 	},
 	{
 		"amqp://example.com:5672",

--- a/sensu/transport/rabbitmq/rabbitmq_config_test.go
+++ b/sensu/transport/rabbitmq/rabbitmq_config_test.go
@@ -1,0 +1,110 @@
+package rabbitmq
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"testing"
+)
+
+func validateStringParameter(
+	actual string,
+	expected string,
+	parameterName string,
+	t *testing.T) {
+
+	if actual != expected {
+		t.Errorf(
+			"Expected %s to be \"%s\" but got \"%s\" instead!",
+			parameterName,
+			expected,
+			actual,
+		)
+	}
+}
+
+func validateError(actual error, expected error, t *testing.T) {
+	if actual == nil {
+		t.Errorf("Expected error to be set but got nil instead!")
+	}
+
+	if actual.Error() != expected.Error() {
+		t.Errorf(
+			"Expected error to be \"%s\" but got \"%s\" instead!",
+			expected,
+			actual,
+		)
+	}
+}
+
+func TestNewTransportConfigHappyFlow(t *testing.T) {
+	expectedHost := "localhost"
+	expectedPort := "5673"
+	expectedVhost := "/sensu"
+	expectedUser := "test_user"
+	expectedPassword := "test_password"
+
+	config, err := NewTransportConfig(fmt.Sprintf(
+		"amqp://%s:%s@%s:%s/%s",
+		expectedUser,
+		expectedPassword,
+		expectedHost,
+		expectedPort,
+		url.QueryEscape(expectedVhost),
+	))
+
+	if err != nil {
+		t.Errorf(
+			"Expected error to be nil but got \"%s\" instead!",
+			err,
+		)
+	}
+
+	if config == nil {
+		t.Errorf("Expected config to not be nil")
+	}
+
+	validateStringParameter(config.Host, expectedHost, "host", t)
+	validateStringParameter(string(config.Port), expectedPort, "port", t)
+	validateStringParameter(config.Vhost, expectedVhost, "vhost", t)
+	validateStringParameter(config.User, expectedUser, "user", t)
+	validateStringParameter(config.Password, expectedPassword, "password", t)
+}
+
+var transportConfigErrorTestScenarios = []struct {
+	uri           string
+	expectedError error
+}{
+	{
+		"",
+		errors.New("Failed to determine the port for host: "),
+	},
+	{
+		"://",
+		errors.New("parse ://: missing protocol scheme"),
+	},
+	{
+		"amqp://example.com/",
+		errors.New("Failed to determine the port for host: example.com"),
+	},
+	{
+		"amqp://example.com::",
+		errors.New("too many colons in address example.com::"),
+	},
+	{
+		"amqp://example.com:5672",
+		errNoUserInURI,
+	},
+}
+
+func TestNewTransportConfigErrorScenarios(t *testing.T) {
+	for _, test := range transportConfigErrorTestScenarios {
+		config, err := NewTransportConfig(test.uri)
+
+		validateError(err, test.expectedError, t)
+
+		if config != nil {
+			t.Errorf("Expected config to be nil")
+		}
+	}
+}

--- a/sensu/transport/rabbitmq/rabbitmq_test.go
+++ b/sensu/transport/rabbitmq/rabbitmq_test.go
@@ -1,0 +1,16 @@
+package rabbitmq
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestTransportConnect(t *testing.T) {
+	testConfig, _ := NewTransportConfig("amqp://guest:guest@localhost:5672/%2F")
+
+	transport := NewRabbitMQHATransport([]*TransportConfig{testConfig})
+
+	err := transport.Connect()
+
+	validateError(err, errors.New("dial tcp [::1]:5672: getsockopt: connection refused"), t)
+}


### PR DESCRIPTION
This is required by https://github.com/upfluence/sensu-client-go/issues/13

Limitations / TODOs for future PRs:
- Prefetch values are currently ignored
- No SSL support
- Documentation enhances

Note: The test for `RabbitMQTransport.Connect` is very basic. Doing more tests requires either adding a wrapper for the amqp functions or possibly using something like [this package](https://github.com/bouk/monkey). Please let me know what are your thoughts on this.

Note 2: I'm reusing a function from rabbitmq_config_test.go in rabbitmq_test.go, which is definitely ugly. I also copied [this function](https://github.com/upfluence/sensu-client-go/blob/master/sensu/config_test.go#L19) from sensu-client-go. I'd rather have these functions in some common place before merging the code. Could you please suggest where I should place them? Perhaps some extra folder in this library?