### PR TITLE
Fix ineffective break statements

### DIFF
--- a/sensu/event/event.go
+++ b/sensu/event/event.go
@@ -37,7 +37,7 @@ func UnmarshalEvent(blob []byte) (*Event, error) {
 
 	if err == nil {
 		for _, rawHistory := range event.Check.RawHistory {
-			if i, err := strconv.Atoi(rawHistory); err == nil {
+			if i, errConv := strconv.Atoi(rawHistory); errConv == nil {
 				event.Check.History = append(event.Check.History, check.ExitStatus(i))
 			}
 		}

--- a/sensu/transport/rabbitmq/rabbitmq.go
+++ b/sensu/transport/rabbitmq/rabbitmq.go
@@ -288,10 +288,10 @@ func (t *RabbitMQTransport) Subscribe(key, exchangeName, queueName string, messa
 				messageChan <- delivery.Body
 			} else {
 				t.ClosingChannel <- true
-				break
+				return nil
 			}
 		case <-stopChan:
-			break
+			return nil
 		}
 	}
 }

--- a/sensu/transport/rabbitmq/rabbitmq_test.go
+++ b/sensu/transport/rabbitmq/rabbitmq_test.go
@@ -230,3 +230,31 @@ func TestTransportConnectError(t *testing.T) {
 
 	validateError(err, errFailedToConnect, t)
 }
+
+func TestTransportSubscribe(t *testing.T) {
+	transport := &RabbitMQTransport{
+		ClosingChannel: make(chan bool),
+		Configs:        []*TransportConfig{getDummyTransportConfig(0, 0)},
+		dialer:         mockAMQPDialer,
+	}
+
+	err := transport.Connect()
+
+	validateError(err, nil, t)
+
+	stopChan := make(chan bool)
+
+	waitForSubscribe := make(chan bool)
+
+	go func() {
+		err = transport.Subscribe("", "", "", nil, stopChan)
+
+		validateError(err, nil, t)
+
+		waitForSubscribe <- true
+	}()
+
+	stopChan <- true
+
+	<-waitForSubscribe
+}


### PR DESCRIPTION
I noticed that `RabbitMQTransport.Subscribe` has an issue with the channel polling logic [here](https://github.com/upfluence/sensu-go/blob/389afcd82a33b6dfd753bcea790c6c584fe07060/sensu/transport/rabbitmq/rabbitmq.go#L203) and [here](https://github.com/upfluence/sensu-go/blob/389afcd82a33b6dfd753bcea790c6c584fe07060/sensu/transport/rabbitmq/rabbitmq.go#L206).

I believe those break statements should be `return nil` instead of `break` and `TestTransportSubscribe` exhibits a deadlock without this change. However, I think sensu-client-go isn't impacted by this issue, given the current usage [here](https://github.com/upfluence/sensu-client-go/blob/f54e3278da6cbf5f9a4a99e090f82bd99d31701d/sensu/subscriber.go#L93).

PS: I don't really understand what's the intended use for `RabbitMQTransport.ClosingChannel` over [here](https://github.com/upfluence/sensu-go/blob/389afcd82a33b6dfd753bcea790c6c584fe07060/sensu/transport/rabbitmq/rabbitmq.go#L202). Does sensu-client-go need to receive that value somewhere? I believe [this code](https://github.com/upfluence/sensu-client-go/blob/f54e3278da6cbf5f9a4a99e090f82bd99d31701d/sensu/client.go#L77) is triggered only when AMQP sends a close notification [here](https://github.com/upfluence/sensu-go/blob/389afcd82a33b6dfd753bcea790c6c584fe07060/sensu/transport/rabbitmq/rabbitmq.go#L104).